### PR TITLE
fix broken link in instructions #staff

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ What won't happen:
 
 2. Build your application. This is going to be different from labs you have done on Learn. Do *not* click `Open IDE` and create your application within the lesson files. Instead:
     - [Watch this video on how to create and continue your project in the IDE In Browser](https://www.youtube.com/watch?time_continue=317&v=YZNXWWHUO-E)
-    - [Use this IDE Sandbox](https://learn.co/tracks/online-software-engineering-structured/procedural-ruby/command-line-applications/cli-applications-in-ruby).
+    - [Use this IDE Sandbox](https://learn.co/tracks/full-stack-web-development-v5/intro-to-ruby-development/command-line-applications/cli-applications-in-ruby).
     *Do not close the Sandbox without completing the next step or your work will be lost.*
     - After your repo is pushed up to Github, make sure you have [a good README.md](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2) with a short description, install instructions, a contributors guide and a link to the license for your code (students usually use the [MIT license](https://opensource.org/licenses/MIT)).
     - To continue working on your project, you'll need to delete extra project files in the Sandbox and clone your project down each time. [This article](http://help.learn.co/workflow-tips/learn-gem/how-to-manually-open-a-lab) includes instructions on how to clone down a repo.


### PR DESCRIPTION
Since there are two other links to the same lesson, I'm hoping this is the right fix so that self-paced students can click and see a lesson with the sandbox link in it.  I just changed the link from structured to v5, which is what it is in the two other places.